### PR TITLE
Turn scope string into an array

### DIFF
--- a/aperture/app/Http/Middleware/VerifyIndieAuthAccessToken.php
+++ b/aperture/app/Http/Middleware/VerifyIndieAuthAccessToken.php
@@ -90,7 +90,7 @@ class VerifyIndieAuthAccessToken
                 $token_data['type'] = 'indieauth';
 
                 if(is_string($token_data['scope']))
-                    $token_data['scope'] = [$token_data['scope']];
+                    $token_data['scope'] = explode(" ", $token_data['scope']);
             }
 
             Cache::set('token:'.$token, json_encode($token_data), 300);


### PR DESCRIPTION
Fixes #9 The code in aperture expects scope to be an array. If we receive a string, we just explode it into an array. Voila.