### PR TITLE
Fix channel scoping

### DIFF
--- a/aperture/app/Http/Controllers/MicrosubController.php
+++ b/aperture/app/Http/Controllers/MicrosubController.php
@@ -31,7 +31,7 @@ class MicrosubController extends Controller
 
   private function _verifyAction($action) {
     $actions = self::_actions();
-    if(!array_key_exists(Request::input('action'), $actions)) {
+    if(!array_key_exists($action, $actions)) {
       return Response::json([
         'error' => 'bad_request', 
         'error_description' => 'This operation is not supported'

--- a/aperture/app/Http/Controllers/MicrosubController.php
+++ b/aperture/app/Http/Controllers/MicrosubController.php
@@ -17,7 +17,8 @@ class MicrosubController extends Controller
       'unmute' => 'mute',
       'block' => 'block',
       'unblock' => 'block',
-      'channels' => 'channels',
+      'read-channels' => 'read',
+      'write-channels' => 'channels',
       'search' => '',
       'preview' => '',
     ];
@@ -60,11 +61,13 @@ class MicrosubController extends Controller
   public function get(Request $request) {
     $token_data = Request::get('token_data');
 
-    $verify = $this->_verifyAction(Request::input('action'));
+    $action = Request::input('action');
+    if ($action == "channels")
+      $action = (Request::isMethod('get') ? 'read-channels' : 'write-channels');
+
+    $verify = $this->_verifyAction();
     if($verify !== true)
       return $verify;
-
-    $action = Request::input('action');
 
     if(!method_exists($this, 'get_'.$action))
       return Response::json([

--- a/aperture/app/Http/Controllers/MicrosubController.php
+++ b/aperture/app/Http/Controllers/MicrosubController.php
@@ -62,10 +62,12 @@ class MicrosubController extends Controller
     $token_data = Request::get('token_data');
 
     $action = Request::input('action');
-    if ($action == "channels")
-      $action = (Request::isMethod('get') ? 'read-channels' : 'write-channels');
+    switch($action) {
+        case 'channels':
+            $action = (Request::isMethod('get') ? 'read-' : 'write-') . $action;
+    }
 
-    $verify = $this->_verifyAction();
+    $verify = $this->_verifyAction($action);
     if($verify !== true)
       return $verify;
 

--- a/aperture/app/Http/Controllers/MicrosubController.php
+++ b/aperture/app/Http/Controllers/MicrosubController.php
@@ -62,12 +62,17 @@ class MicrosubController extends Controller
     $token_data = Request::get('token_data');
 
     $action = Request::input('action');
+
     switch($action) {
+        // Any items that have a different read/write scope, should be added as cases
         case 'channels':
-            $action = (Request::isMethod('get') ? 'read-' : 'write-') . $action;
+            $scopeKey = 'read-'.$action;
+            break;
+        default:
+            $scopeKey = $action;
     }
 
-    $verify = $this->_verifyAction($action);
+    $verify = $this->_verifyAction($scopeKey);
     if($verify !== true)
       return $verify;
 
@@ -77,7 +82,7 @@ class MicrosubController extends Controller
         'error_description' => 'This method has not yet been implemented'
       ], 400);
 
-    if(!$this->_verifyScopeForAction($action)) {
+    if(!$this->_verifyScopeForAction($scopeKey)) {
       return Response::json([
         'error' => 'unauthorized',
         'error_description' => 'The access token provided does not have the necessary scope for this action',
@@ -90,11 +95,20 @@ class MicrosubController extends Controller
   public function post(Request $request) {
     $token_data = Request::get('token_data');
 
-    $verify = $this->_verifyAction(Request::input('action'));
+    $action = Request::input('action');
+
+    switch($action) {
+      // Any items that have a different read/write scope, should be added as cases
+      case 'channels':
+          $scopeKey = 'write-'.$action;
+          break;
+      default:
+          $scopeKey = $action;
+    }
+
+    $verify = $this->_verifyAction($scopeKey);
     if($verify !== true)
       return $verify;
-
-    $action = Request::input('action');
 
     if(!method_exists($this, 'post_'.$action))
       return Response::json([
@@ -102,7 +116,7 @@ class MicrosubController extends Controller
         'error_description' => 'This method has not yet been implemented'
       ], 400);
     
-    if(!$this->_verifyScopeForAction($action)) {
+    if(!$this->_verifyScopeForAction($scopeKey)) {
       return Response::json([
         'error' => 'unauthorized',
         'error_description' => 'The access token provided does not have the necessary scope for this action',

--- a/aperture/app/Http/Middleware/VerifyIndieAuthAccessToken.php
+++ b/aperture/app/Http/Middleware/VerifyIndieAuthAccessToken.php
@@ -90,7 +90,7 @@ class VerifyIndieAuthAccessToken
                 $token_data['type'] = 'indieauth';
 
                 if(is_string($token_data['scope']))
-                    $token_data['scope'] = [$token_data['scope']];
+                    $token_data['scope'] = explode(" ", $token_data['scope']);
             }
 
             Cache::set('token:'.$token, json_encode($token_data), 300);


### PR DESCRIPTION
Fixes #10 Where the channel's read and write scopes are different. Introduced a "scopeKey" which is based on the action variable. Added a switch, so that if there are different actions in the future that need read/write scope keys, we can just add another case to that switch and it should automatically work.

If you want to solve this a different way, feel free. This is just what came to my mind.