### PR TITLE
default APP_DEBUG to false in .env.example

### DIFF
--- a/aperture/.env.example
+++ b/aperture/.env.example
@@ -1,7 +1,7 @@
 APP_NAME=Aperture
 APP_ENV=local
 APP_KEY=
-APP_DEBUG=true
+APP_DEBUG=false
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost
 


### PR DESCRIPTION
I got dinged by a Laravel debug mode exploit that let an attacker get my `.env` file with some email-sending credentials. Oops!

I suggest shipping an env example where `APP_DEBUG` is set to `false` by default. 😅