### PR TITLE
minimal support for action=channels&method=tree

### DIFF
--- a/aperture/app/Channel.php
+++ b/aperture/app/Channel.php
@@ -33,7 +33,7 @@ class Channel extends Model {
     return $types;
   }
 
-  public function to_array() {
+  public function to_array($include_sources = false) {
     $array = [
       'uid' => $this->uid,
       'name' => $this->name,
@@ -48,6 +48,18 @@ class Channel extends Model {
     }
     if($this->default_destination) {
       $array['destination'] = $this->default_destination;
+    }
+    if($include_sources) {
+      $sources = $this->sources()->get();
+      $array['sources'] = [];
+      foreach($sources as $source) {
+        $source_array = $source->to_array();
+
+        $array['sources'][] = array_merge([
+          '_id' => $source->id,
+          'url' => $source->url
+        ], $source_array);
+      }
     }
     return $array;
   }

--- a/aperture/app/Http/Controllers/MicrosubController.php
+++ b/aperture/app/Http/Controllers/MicrosubController.php
@@ -144,10 +144,11 @@ class MicrosubController extends Controller
   //////////////////////////////////////////////////////////////////////////////////
 
   private function get_channels() {
+    $include_sources = (Request::input('method') == 'tree');
     $channels = [];
 
     foreach(Auth::user()->channels()->get() as $channel) {
-      $channels[] = $channel->to_array();
+      $channels[] = $channel->to_array($include_sources);
     }
 
     return [


### PR DESCRIPTION
Partially fulfills https://github.com/indieweb/microsub/issues/44

When `method=tree` is supplied to an `action=channels` GET request, a `sources` array will be included with each `channel` of the form:

```json
{
  "channels": [
    {
      "sources": [
        {
          "_id": 123,
          "url": "http://example.com/",
          "name": "Channel name"
        }
      ]
    }
  ]
}
```

I haven't included info like per-source unread count or last-checked time. I basically only included "easy" information that was obvious in the DB schema.

No time pressure on this. Feel free to treat it as a discussion piece. :}